### PR TITLE
Stop using hardcoded account service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=2
-PATCH_VER=2
+PATCH_VER=3
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/authorize.lua
+++ b/src/authorize.lua
@@ -35,7 +35,7 @@ local service_host = string.match(original_host, "^([^.]+)")
 local service = nil
 
 -- catch calls to the account service resource from subdomain based routes
-if service_uri and service_mappings[service_uri] == "auth" then
+if service_uri and service_mappings[service_uri] == service_mappings["account"] then
   ngx.log(ngx.DEBUG, "==== trying to access account service")
   service = service_mappings[service_uri]
 end


### PR DESCRIPTION
When service_mappings[account] is configured to something other than
"auth", this code was causing no auth-token to be set. This now is
looking at the configurable value.

Bump patch version