### PR TITLE
Support longer path-based services, make domain default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=2
-PATCH_VER=3
+PATCH_VER=4
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/config/nginx.conf.sample
+++ b/src/config/nginx.conf.sample
@@ -52,7 +52,7 @@ http {
   }
 
   # Service mappings, map service urls to service names
-  init_by_lua 'service_mappings = {b="srsbsns", c="enterprize", account="auth"}
+  init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/c"]="enterprize", ["/account"]="auth"}
                subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
                account_resource = "/account"
                statsd_namespace = "borderpatrol"
@@ -69,6 +69,7 @@ http {
     include '../session.conf';
     include '../account.conf';
     include '../common_locations.conf';
+    include '../service_locations.conf';
 
     location ~ ^/ {
       include '../location_defaults.conf';
@@ -85,6 +86,7 @@ http {
     include '../session.conf';
     include '../account.conf';
     include '../common_locations.conf';
+    include '../service_locations.conf';
 
     location ~ ^/ {
       include '../location_defaults.conf';
@@ -99,6 +101,7 @@ http {
 
     include '../session.conf';
     include '../common_locations.conf';
+    include '../service_locations.conf';
 
     location = / {
       limit_req zone=auth_zone burst=25;
@@ -108,12 +111,6 @@ http {
       if ($request_method = GET ) {
         return 301 $scheme://$host:$server_port/account/settings;
       }
-    }
-
-    location ~ ^/(b|c|account) {
-      include '../location_defaults.conf';
-      rewrite ^/(.*) / break;
-      proxy_pass http://$1;
     }
 
     # This should be the last location directive, designed to capture any

--- a/src/config/service_locations.conf
+++ b/src/config/service_locations.conf
@@ -1,0 +1,5 @@
+location ~ ^/(b|c|account) {
+  include '../location_defaults.conf';
+  rewrite ^/(.*) / break;
+  proxy_pass http://$1;
+}

--- a/src/service.lua
+++ b/src/service.lua
@@ -1,0 +1,67 @@
+local module = {}
+
+-- checks if the string starts with the value
+local function starts_with(str, starts)
+  return string.sub(str, 1, string.len(starts)) == starts
+end
+
+-- find the longest subsequence
+local function longest_subseq(tbl)
+  local max = 0
+  local max_i = 1
+  for i,str in ipairs(tbl) do
+    cur = string.len(str)
+    if cur > max then
+      max_i = i
+      max = cur
+    end
+  end
+  return tbl[max_i]
+end
+
+-- return the service mapping key with the longest subsequence match of the string
+-- with host sub.subdomain.example.com
+local function match_service(tbl, str)
+  local subseqs = {}
+  for cmpt,service in pairs(tbl) do
+    if starts_with(str, cmpt) then
+      table.insert(subseqs, cmpt)
+    end
+  end
+  return tbl[longest_subseq(subseqs)]
+end
+
+-- Given a host of "sub.subdomain.example.org", and a subdomain_mapping table of {["sub.subdomain"]="name", ["sub"]="name2"}
+-- return "name", since "sub.subdomain" is the longest matching subsequence
+local function match_subdomain(host)
+  local service = match_service(subdomain_mappings, host)
+  if not service then
+    ngx.log(ngx.WARN, "==== no service found for host: " .. host)
+  end
+  return service
+end
+
+-- Given a path of "/api/service/collection/1/id", and a service_mapping table of {["/api/service"]="name", ["/api/service2"]="name2"}
+-- return "name" since "/api/service" is the longest matching subsequence
+-- matches the given url against the service_mappings, returns the service or nil
+local function match_path(path)
+  local service = match_service(service_mappings, path)
+  if not service then
+    ngx.log(ngx.WARN, "==== no service found for path: " .. path)
+  end
+  return service
+end
+
+local function find_service(path, host)
+  local service = match_path(path)
+  if not service then
+    service = match_subdomain(host)
+  end
+  return service
+end
+
+module.find_service = find_service
+module.match_path = match_path
+module.match_host = match_host
+
+return module

--- a/t/authorize.t
+++ b/t/authorize.t
@@ -16,7 +16,7 @@ __DATA__
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -49,7 +49,7 @@ STORED\r
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -99,7 +99,7 @@ Location: http://localhost(?::\d+)?/b$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -148,7 +148,7 @@ Location: http://localhost(?::\d+)?/b$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -189,7 +189,7 @@ Location: http://localhost(?::\d+)?/b$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -238,7 +238,7 @@ Location: http://localhost(?::\d+)?/b$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -287,7 +287,7 @@ Location: http://localhost(?::\d+)?/b$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config
@@ -337,7 +337,7 @@ Location: http://business.localhost(?::\d+)?$
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {b="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
              account_resource = "/account"';
 --- config

--- a/t/validate.t
+++ b/t/validate.t
@@ -19,7 +19,7 @@ __DATA__
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {auth="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/auth"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}';
 --- config
 location /memc_setup {
@@ -168,7 +168,7 @@ STORED\r
 --- http_config
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
-init_by_lua 'service_mappings = {auth="srsbsns", s="enterprize"}
+init_by_lua 'service_mappings = {["/auth"]="srsbsns", ["/s"]="enterprize"}
              subdomain_mappings = {business="srsbsns", enterprise="enterprize"}';
 --- config
 location /memc_setup {


### PR DESCRIPTION
The use case for domain routing is really as a default to go to in case
no service is specified in the path. Further, a path->service may
require a longer path than the first component of a path, e.g.
/api/service vs /service. This also applies to subdomains->service, e.g.
sub.domain.com vs sub.sub2.domain.com.

This adds longest-substring matching for subdomain and path matches so
that we specify an entire subpath or entire subdomain to match proper
service name lookup.

Example:
  service_mappings = {["/api"]="service_api", ["/api/service1"]="service1"}
  subdomain_mappings = {["api.subdomain"]="service1", api="service_api"}

Maps the following URIs to their service name:
  api.example.com/ => service_api
  api.example.com/api/service1 => service1
  api.subdomain.example.com/ => service1
  api.subdomain.example.com/api => service_api