### PR TITLE
Match on terminated subsequences

### DIFF
--- a/src/service.lua
+++ b/src/service.lua
@@ -21,10 +21,11 @@ end
 
 -- return the service mapping key with the longest subsequence match of the string
 -- with host sub.subdomain.example.com
-local function match_service(tbl, str)
+-- term is used to terminate the sequence, i.e. "." for subdomains, "/" for path
+local function match_service(tbl, str, term)
   local subseqs = {}
   for cmpt,service in pairs(tbl) do
-    if starts_with(str, cmpt) then
+    if starts_with(str .. term, cmpt .. term) then
       table.insert(subseqs, cmpt)
     end
   end
@@ -34,7 +35,7 @@ end
 -- Given a host of "sub.subdomain.example.org", and a subdomain_mapping table of {["sub.subdomain"]="name", ["sub"]="name2"}
 -- return "name", since "sub.subdomain" is the longest matching subsequence
 local function match_subdomain(host)
-  local service = match_service(subdomain_mappings, host)
+  local service = match_service(subdomain_mappings, host, ".")
   if not service then
     ngx.log(ngx.WARN, "==== no service found for host: " .. host)
   end
@@ -45,7 +46,7 @@ end
 -- return "name" since "/api/service" is the longest matching subsequence
 -- matches the given url against the service_mappings, returns the service or nil
 local function match_path(path)
-  local service = match_service(service_mappings, path)
+  local service = match_service(service_mappings, path, "/")
   if not service then
     ngx.log(ngx.WARN, "==== no service found for path: " .. path)
   end


### PR DESCRIPTION
Without using a termination character to delimit the substring, the path
"/admin" will match a service_mapping of {"/a"=...} as would the
subdomain of "subdomain.example.com" matching {"sub"=...}.

This introduces a "term" character for paths ("/") and for domains
("."), now a path of "/admin" will be compared as such:
starts_with("/admin/", "/a/") which will fail