### PR TITLE
Harden against session fixation attacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
-MINOR_VER=2
-PATCH_VER=5
+MINOR_VER=3
+PATCH_VER=0
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 


### PR DESCRIPTION
We refresh the border_session cookie value once the user successfully
authenticates so that an attacker cannot use an existing session id to
gain access to a victim's authenticated session

Bump up to version 0.3