### PR TITLE
Add failure and version to health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=3
-PATCH_VER=0
+PATCH_VER=1
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/config/nginx.conf.sample
+++ b/src/config/nginx.conf.sample
@@ -58,7 +58,8 @@ http {
                statsd_namespace = "borderpatrol"
                statsd_prefix = "staging"
                statsd_host = "localhost"
-               statsd_port = 8125';
+               statsd_port = 8125
+               bp_version = "0.3.1"';
 
   # business.localhost => b
   server {

--- a/src/health_check.lua
+++ b/src/health_check.lua
@@ -2,54 +2,72 @@
 -- This script serves up an HTML page that displays current health of the
 -- BorderPatrol. The only check, currently, is that memcache is reachable.
 --
-local errors = {}
 local health_check = {}
 
 -- print out the actual HTML
 function health_check.output(errors)
-  ngx.header.content_type = 'text/html';
-  ngx.print([[
+  local output = [[
   <html>
     <head>
       <title>Border Patrol Health</title>
     </head>
     <body>
-  ]])
+  ]]
+
+  output = output .. "<h3>Version " .. bp_version .. "</h3>"
 
   if #errors > 0 then
-    ngx.print("<h3>Errors</h3><ul>")
+    output = output .. "<h3>Errors</h3><ul>"
     for i, v in ipairs(errors) do
-      ngx.print("<li>" .. v .. "</li>")
+      output = output .. "<li>" .. v .. "</li>"
     end
-    ngx.print("</ul>")
+    output = output .. "</ul>"
   else
-    ngx.print("Everything is ok.")
+    output = output .. "Everything is ok."
   end
 
-  ngx.print([[
+  output = output .. [[
     </body>
   </html>
-  ]])
+  ]]
+
+  return output
 end
 
-local res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_POST, body = os.time() })
-if not res.status == ngx.HTTP_OK then
-  errors[#errors+1] = "memcache add: " .. res.status .. ": " .. res.body
+local function get_errors()
+  local errors = {}
+  local res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_POST, body = os.time() })
+  if not (res.status == ngx.HTTP_CREATED) then
+    errors[#errors+1] = "memcache add: " .. res.status .. ": " .. res.body
+  end
+
+  res = ngx.location.capture('/session?id=health_check')
+  if not (res.status == ngx.HTTP_OK) then
+    errors[#errors+1] = "memcache get: " .. res.status .. ": " .. res.body
+  end
+
+  res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_PUT, body = os.time() })
+  if not (res.status == ngx.HTTP_CREATED) then
+    errors[#errors+1] = "memcache set: " .. res.status .. ": " .. res.body
+  end
+
+  res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_DELETE })
+  if not (res.status == ngx.HTTP_OK) then
+    errors[#errors+1] = "memcache delete: " .. res.status .. ": " .. res.body
+  end
+
+  return errors
 end
 
-res = ngx.location.capture('/session?id=health_check')
-if not res.status == ngx.HTTP_OK then
-  errors[#errors+1] = "memcache get: " .. res.status .. ": " .. res.body
+
+local errors = get_errors()
+local output = health_check.output(errors)
+
+if (#errors > 0) then
+  ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+else
+  ngx.status = ngx.HTTP_OK
 end
 
-res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_PUT, body = os.time() })
-if not res.status == ngx.HTTP_OK then
-  errors[#errors+1] = "memcache set: " .. res.status .. ": " .. res.body
-end
-
-res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_DELETE })
-if not res.status == ngx.HTTP_OK then
-  errors[#errors+1] = "memcache delete: " .. res.status .. ": " .. res.body
-end
-
-health_check.output(errors)
+ngx.header.content_type = 'text/html'
+ngx.print(output)

--- a/t/health.t
+++ b/t/health.t
@@ -11,17 +11,17 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: heath controller
+=== TEST 1: heath controller success
 --- main_config
 --- http_config
+init_by_lua 'bp_version = "0.6.666"';
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
 --- config
     location = /session {
+      internal;
       set $memc_key $arg_id;
-      set $memc_exptime 10;
 
-      memc_cmds_allowed get set add delete;
       memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
     }
 
@@ -31,3 +31,24 @@ lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
 --- request
     GET /health
 --- error_code: 200
+
+=== TEST 2: heath controller failure
+--- main_config
+--- http_config
+init_by_lua 'bp_version = "0.6.666"';
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+--- config
+    location = /session {
+      internal;
+      set $memc_key $arg_id;
+
+      memc_pass 127.0.0.1:43212;
+    }
+
+    location /health {
+        content_by_lua_file '../../build/usr/share/borderpatrol/health_check.lua';
+    }
+--- request
+    GET /health
+--- error_code: 500


### PR DESCRIPTION
This health check previously only returned 200 and never gave errors in
the output. For posterity, we'll add the version info, too.