### PR TITLE
Ensure health check uses unique key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=3
-PATCH_VER=1
+PATCH_VER=2
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/config/nginx.conf.sample
+++ b/src/config/nginx.conf.sample
@@ -59,7 +59,7 @@ http {
                statsd_prefix = "staging"
                statsd_host = "localhost"
                statsd_port = 8125
-               bp_version = "0.3.1"';
+               bp_version = "0.3.2"';
 
   # business.localhost => b
   server {

--- a/src/health_check.lua
+++ b/src/health_check.lua
@@ -3,6 +3,7 @@
 -- BorderPatrol. The only check, currently, is that memcache is reachable.
 --
 local health_check = {}
+math.randomseed(os.time())
 
 -- print out the actual HTML
 function health_check.output(errors)
@@ -36,22 +37,24 @@ end
 
 local function get_errors()
   local errors = {}
-  local res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_POST, body = os.time() })
+  local param = "health_check" .. math.random()
+
+  local res = ngx.location.capture('/session?id=' .. param, { method = ngx.HTTP_POST, body = os.time() })
   if not (res.status == ngx.HTTP_CREATED) then
     errors[#errors+1] = "memcache add: " .. res.status .. ": " .. res.body
   end
 
-  res = ngx.location.capture('/session?id=health_check')
+  res = ngx.location.capture('/session?id=' .. param)
   if not (res.status == ngx.HTTP_OK) then
     errors[#errors+1] = "memcache get: " .. res.status .. ": " .. res.body
   end
 
-  res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_PUT, body = os.time() })
+  res = ngx.location.capture('/session?id=' .. param, { method = ngx.HTTP_PUT, body = os.time() })
   if not (res.status == ngx.HTTP_CREATED) then
     errors[#errors+1] = "memcache set: " .. res.status .. ": " .. res.body
   end
 
-  res = ngx.location.capture('/session?id=health_check', { method = ngx.HTTP_DELETE })
+  res = ngx.location.capture('/session?id=' .. param, { method = ngx.HTTP_DELETE })
   if not (res.status == ngx.HTTP_OK) then
     errors[#errors+1] = "memcache delete: " .. res.status .. ": " .. res.body
   end


### PR DESCRIPTION
There is a race condition when deploying to multiple servers where the
CRUD operations cause intermittent 500s