### PR TITLE
Add external aggregate health checks in JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=3
-PATCH_VER=2
+PATCH_VER=3
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/config/nginx.conf.sample
+++ b/src/config/nginx.conf.sample
@@ -55,6 +55,7 @@ http {
   init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/c"]="enterprize", ["/account"]="auth"}
                subdomain_mappings = {business="srsbsns", enterprise="enterprize"}
                account_resource = "/account"
+               health_checks = {account="/account/health", business="/b/health"}
                statsd_namespace = "borderpatrol"
                statsd_prefix = "staging"
                statsd_host = "localhost"

--- a/src/config/session.conf
+++ b/src/config/session.conf
@@ -8,6 +8,13 @@ location = /session {
   memc_pass session_store;
 }
 
+location = /session/health {
+  internal;
+  set $memc_cmd $arg_cmd;
+  set $memc_exptime $arg_exptime;
+  memc_pass session_store;
+}
+
 # DELETE /session_delete?id=foo -> memcache delete
 location = /session_delete {
   internal;

--- a/t/health.t
+++ b/t/health.t
@@ -14,20 +14,30 @@ __DATA__
 === TEST 1: heath controller success
 --- main_config
 --- http_config
-init_by_lua 'bp_version = "0.6.666"';
+init_by_lua 'bp_version = "0.6.666"
+             health_checks = {account="/account/health", business="/business/health"}';
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
 --- config
-    location = /session {
+    location = /session/health {
       internal;
-      set $memc_key $arg_id;
-
+      set $memc_cmd $arg_cmd;
+      set $memc_exptime $arg_exptime;
       memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
     }
 
     location /health {
-        content_by_lua_file '../../build/usr/share/borderpatrol/health_check.lua';
+      content_by_lua_file '../../build/usr/share/borderpatrol/health_check.lua';
     }
+
+    location /account/health {
+      return 200 "{\"version\": \"1.2.3\"}";
+    }
+
+    location /business/health {
+      return 200 "{\"version\": \"2.3.4\"}";
+    }
+
 --- request
     GET /health
 --- error_code: 200
@@ -35,19 +45,28 @@ lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
 === TEST 2: heath controller failure
 --- main_config
 --- http_config
-init_by_lua 'bp_version = "0.6.666"';
+init_by_lua 'bp_version = "0.6.666"
+             health_checks = {account="/account/health", business="/business/health"}';
 lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
 lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
 --- config
-    location = /session {
+    location = /session/health {
       internal;
-      set $memc_key $arg_id;
-
-      memc_pass 127.0.0.1:43212;
+      set $memc_cmd $arg_cmd;
+      set $memc_exptime $arg_exptime;
+      memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
     }
 
     location /health {
-        content_by_lua_file '../../build/usr/share/borderpatrol/health_check.lua';
+      content_by_lua_file '../../build/usr/share/borderpatrol/health_check.lua';
+    }
+
+    location /account/health {
+      return 200 "{\"version\": \"1.2.3\"}";
+    }
+
+    location /business/health {
+      return 500 "{\"version\": \"2.3.4\"}";
     }
 --- request
     GET /health


### PR DESCRIPTION
Border Patrol currently depends on several upstream services for it to
work properly. Since the lack of certain services renders it useless, we
should report that in our health checks.

Further, the usefulness of CRUD checks in memcached is proving to be
more trouble than it's worth. Instead, it will report the stats for
memcached