### PR TITLE
Fix issue with null pointer error parsing invalid json from auth service

### DIFF
--- a/src/validate.lua
+++ b/src/validate.lua
@@ -53,12 +53,20 @@ if res.status == ngx.HTTP_OK then
 
         -- TODO Check response status (in this case, don't do anything, treat it as missing token)
         local specific_token_json = res.body
-        auth_token = json.decode(specific_token_json, {nothrow = true})['service_tokens'][service]
+        service_tokens = json.decode(specific_token_json, {nothrow = true})
+        auth_token = nil
+
+        if service_tokens then
+          auth_token = service_tokens['service_tokens'][service]
+        else
+          ngx.log(ngx.WARN, "==== unable to parse response from auth service " .. specific_token_json)
+        end
+
         if auth_token then
           all_tokens['service_tokens'][service] = auth_token
           all_tokens_json = json.encode(all_tokens)
+          ngx.log(ngx.INFO, "==== retrieved service token for service: " .. service .. " " .. auth_token)
         end
-        ngx.log(ngx.INFO, "==== retrieved service token for service: " .. service .. " " .. auth_token)
       end
     end
     -- reset the auth_token TTL to maintain a rolling session window

--- a/t/validate.t
+++ b/t/validate.t
@@ -210,3 +210,48 @@ STORED\r
 STORED\r
 STORED\r
 .*401.*
+
+=== TEST 6: test valid sessionid but auth service returns invalid json
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+init_by_lua 'service_mappings = {["/auth"]="srsbsns", ["/s"]="enterprize"}
+             subdomain_mappings = {business="srsbsns", enterprise="enterprize"}';
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+    echo_subrequest POST '/memc_setup?key=BPSID_MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*' -b '{"auth_service": "aaa","service_tokens": {"randomservice": "bbb"}}';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /serviceauth {
+    echo_status 200;
+    echo 'Invalid JSON';
+    echo_flush;
+}
+
+location = /validate {
+    content_by_lua_file '../../build/usr/share/borderpatrol/validate.lua';
+}
+
+--- request eval
+["GET /setup", "GET /validate"]
+--- more_headers
+Content-type: application/x-www-form-urlencoded
+Cookie: border_session=MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code eval
+[200,401]


### PR DESCRIPTION
If the Auth Service returns invalid json we were not checking to see
whether we got back a valid value from json parse method. This was
resulting in an npe with the following error that would result in a 500
to the client

lua entry thread aborted: runtime error:
/usr/share/borderpatrol/validate.lua:56: attempt to index a nil value