### PR TITLE
When redirecting user with session, if no redirect url redirect to de…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "contrib/nginx"]
 	path = contrib/nginx
-	url = https://github.com/nginx/nginx.git
+	url = https://github.com/nginx/nginx-releases.git
 [submodule "contrib/ngx_devel_kit"]
 	path = contrib/ngx_devel_kit
 	url = https://github.com/simpl/ngx_devel_kit.git

--- a/src/authorize.lua
+++ b/src/authorize.lua
@@ -104,5 +104,11 @@ ngx.log(ngx.DEBUG, "==== PUT /session?id=BPSID_" .. new_session_id  ..
 ngx.log(ngx.DEBUG, "==== setting new cookie session_id " .. new_session_id)
 ngx.header['Set-Cookie'] = 'border_session=' .. new_session_id .. '; path=/; HttpOnly; Secure;'
 
+-- If no original url use default url for service
+if not original_url or original_url == "" then
+  original_url = service_matcher.default_url_for_service(service)
+  ngx.log(ngx.DEBUG, "==== blank original url, setting to default of " .. original_url)
+end
+
 ngx.log(ngx.DEBUG, "==== redirecting to origin url " .. original_url)
 ngx.redirect(original_url)

--- a/src/service.lua
+++ b/src/service.lua
@@ -61,6 +61,18 @@ local function find_service(path, host)
   return service
 end
 
+-- Get default url for given service. If none, return "/"
+local function default_url_for_service(service)
+  default_url = "/"
+  for key,value in pairs(service_mappings) do
+    if value == service then
+      default_url = key
+    end
+  end
+  return default_url
+end
+
+module.default_url_for_service = default_url_for_service
 module.find_service = find_service
 module.match_path = match_path
 module.match_host = match_host

--- a/t/authorize.t
+++ b/t/authorize.t
@@ -5,7 +5,7 @@ $ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
 
 repeat_each(1);
 
-plan tests => repeat_each() * (2 * blocks()) - 1;
+plan tests => (repeat_each() * (2 * blocks())) + 3;
 
 run_tests();
 
@@ -380,3 +380,62 @@ Set-Cookie: border_session=.+:.+; path=/; HttpOnly; Secure;$
 Location: http://localhost(?::\d+)?$
 --- error_code eval
 [200,302]
+
+=== TEST 8: test redirect to default url for given service/domain
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+init_by_lua 'service_mappings = {["/b"]="srsbsns", ["/s"]="enterprize"}
+             subdomain_mappings = {localhost="srsbsns", enterprise="enterprize"}
+             account_resource = "/account"';
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /session_delete {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+    echo_subrequest POST '/memc_setup?key=BP_URL_SID_MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*' -b '/b';
+    echo_status 200;
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /delete {
+   echo_subrequest DELETE '/session_delete?id=BP_URL_SID_MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*';
+   echo_subrequest POST '/memc_setup?key=BP_URL_SID_MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*' -b '';
+   echo_status 200;
+   echo_flush;
+}
+location /authorize { # under test
+    content_by_lua_file '../../build/usr/share/borderpatrol/authorize.lua';
+}
+location /account {
+    internal;
+    echo_status 200;
+    echo '{"auth_service": "tokentokentokentoken", "service_tokens": {"srsbsns": "tokentokentokentoken"}}';
+    echo_flush;
+}
+--- request eval
+["GET /setup", "GET /delete", "POST /authorize
+    username=foo&password=bar"]
+--- more_headers
+Content-type: application/x-www-form-urlencoded
+Cookie: border_session=MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- response_headers eval
+["Location: ","Location: ", "Location: http://localhost:1984/b"]
+--- error_code eval
+[200, 200, 302]


### PR DESCRIPTION
…fault

For users without a borderpatrol session we store in memcache the url
they were going to so that we can redirect them there after logging in. If
a logged in user accesses /a, since we deleted the redirect url when they
got the session, we end up redirecting to "". If we are about to redirect
to "" redirect to the default for the service. If there is no default
redirect to "/".

It also seems that different browsers handle redirects to "" differently.
Chrome does nothing, while Safari and Firefox redirect to "/"