### PR TITLE
Add CSRF protection for authenticated requests

### DIFF
--- a/src/authorize.lua
+++ b/src/authorize.lua
@@ -1,6 +1,7 @@
 local json = require("json")
 local sessionid = require("sessionid")
 local service_matcher = require("service")
+local cookie = require("cookie")
 
 -------------------------------------------
 --  Make the call to the Account Service
@@ -100,9 +101,9 @@ local res = ngx.location.capture('/session?id=BPSID_' .. new_session_id ..
 ngx.log(ngx.DEBUG, "==== PUT /session?id=BPSID_" .. new_session_id  ..
   '&arg_exptime=' .. sessionid.EXPTIME .. " " .. res.status)
 
--- Ensure we set a new cookie with the new session id
-ngx.log(ngx.DEBUG, "==== setting new cookie session_id " .. new_session_id)
-ngx.header['Set-Cookie'] = 'border_session=' .. new_session_id .. '; path=/; HttpOnly; Secure;'
+-- Ensure we set a new cookie with the new session id, and the csrf cookie
+ngx.log(ngx.DEBUG, "==== setting new session cookie: " .. new_session_id)
+cookie.set_all(new_session_id)
 
 -- If no original url use default url for service
 if not original_url or original_url == "" then

--- a/src/config/location_defaults.conf
+++ b/src/config/location_defaults.conf
@@ -10,6 +10,11 @@ set $auth_token $http_auth_token;
 access_by_lua_file '../../build/usr/share/borderpatrol/access.lua';
 proxy_set_header Auth-token $auth_token;
 
+# Inject the CSRF protection header for every authenticated request
+set $csrf_verified 'false';
+access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
 # tell upstreams the $schema
 proxy_set_header X-Forwarded-Proto $scheme;
 # tell upstreams they are behind borderpatrol

--- a/src/cookie.lua
+++ b/src/cookie.lua
@@ -1,0 +1,65 @@
+local sessionid = require("sessionid")
+
+local module = {}
+
+local session_cookie_name = 'border_session'
+local csrf_cookie_name = 'border_csrf'
+
+--
+-- Creates the cookie from the name and value parameters
+--
+local function make_cookie(name, value)
+  return (name .. '=' .. value .. '; path=/; HttpOnly; Secure;')
+end
+
+--
+-- Creates an empty value and sets the cookie as expired (now() - 1yr)
+--
+local function make_expired_cookie(name)
+  return (make_cookie(name, '') .. 'expires=' .. ngx.cookie_time(ngx.time() - 3600 * 24 * 360))
+end
+
+--
+-- Returns the cookie for sessions
+-- session_id The id for the session cookie
+--
+local function gen_session(session_id)
+  return make_cookie(session_cookie_name, session_id)
+end
+
+--
+-- Creates the cookie for csrf protection, generating a unique id for it
+--
+local function gen_csrf()
+  return make_cookie(csrf_cookie_name, sessionid.generate())
+end
+
+--
+-- Mutates the Set-Cookie header with both the session and csrf cookies injected
+-- session_id The id for the session cookie
+--
+local function set_cookie_header(session_id)
+  ngx.header['Set-Cookie'] = {gen_session(session_id), gen_csrf()}
+end
+
+--
+-- Mutates the Set-Cookie header with only the session cookie injected
+-- session_id The id for the session cookie
+--
+local function set_session_cookie_header(session_id)
+  ngx.header['Set-Cookie'] = gen_session(session_id)
+end
+
+--
+-- Mutates the Set-Cookie header with expired cookies
+--
+local function expire_cookies()
+  ngx.header['Set-Cookie'] = {make_expired_cookie(session_cookie_name),
+                              make_expired_cookie(csrf_cookie_name)}
+end
+
+module.set_all = set_cookie_header
+module.set_session = set_session_cookie_header
+module.expire_all = expire_cookies
+
+return module

--- a/src/csrf.lua
+++ b/src/csrf.lua
@@ -1,0 +1,84 @@
+local sessionid = require("sessionid")
+
+local module = {}
+local csrf_verified_hdr = 'X-Border-Csrf-Verified'
+local csrf_incoming_hdr = 'X-Border-Csrf'
+
+--
+-- Boolean: token and header are present, also logs if false
+-- token The cookie value
+-- header The header value
+--
+local function csrf_present(token, header)
+  if (token == nil) then
+    ngx.log(ngx.DEBUG, "=== no csrf cookie")
+  end
+
+  if (header == nil) then
+    ngx.log(ngx.DEBUG, "=== no csrf header")
+  end
+
+  return (not (not (token and header)))
+end
+
+--
+-- Boolean: token and header are equivalent, also logs if false
+-- token The cookie value
+-- header The header value
+--
+local function csrf_equal(token, header)
+  local equiv = token == header
+
+  if (not equiv) then
+    ngx.log(ngx.DEBUG, "=== cookie != header: " .. token .. " != " .. header)
+  end
+
+  return equiv
+end
+
+--
+-- Boolean: cookie and header are valid, also logs if false
+-- token The cookie value
+-- header The header value
+--
+local function verify_csrf_tokens(token, header)
+  local valid_cookie = sessionid.is_valid(token)
+  local valid_header = sessionid.is_valid(header)
+
+  if (not valid_cookie) then
+    ngx.log(ngx.DEBUG, "=== invalid csrf cookie: " .. token)
+  end
+
+  if (not valid_header) then
+    ngx.log(ngx.DEBUG, "=== invalid csrf header: " .. header)
+  end
+
+  return (valid_cookie and valid_header)
+end
+
+--
+-- Boolean: the cookie and header tokens are present, valid, and equivalent
+-- token The csrf cookie value
+-- header The csrf header value
+--
+local function is_valid(token, header)
+  return (csrf_present(token, header) and csrf_equal(token, header) and verify_csrf_tokens(token, header))
+end
+
+--
+-- Sets the $csrf_verified nginx variable to 'true' or 'false'
+--
+local function set_csrf_verified()
+  local csrf_tkn = ngx.var.cookie_border_csrf
+  local csrf_hdr = ngx.req.get_headers()[csrf_incoming_hdr]
+
+  if is_valid(csrf_tkn, csrf_hdr) then
+    ngx.log(ngx.DEBUG, "csrf valid")
+    ngx.var.csrf_verified = 'true'
+  else
+    ngx.var.csrf_verified = 'false'
+  end
+
+end
+
+set_csrf_verified()

--- a/src/logout.lua
+++ b/src/logout.lua
@@ -1,3 +1,4 @@
+local cookie = require("cookie")
 -------------------------------------------
 -- delete auth token by session id
 -------------------------------------------
@@ -25,13 +26,10 @@ if session_id then
     { method = ngx.HTTP_DELETE })
 
   ngx.log(ngx.DEBUG, "DELETE /session_delete?id=BP_URL_SID_" .. session_id .. " " .. res.status)
-
-  -- unset session cookie (expires now() - 1yr)
-  ngx.header['Set-Cookie'] = 'border_session=' ..
-    '; path=/; expires=' .. ngx.cookie_time(ngx.time() - 3600 * 24 * 360)
-
 else
-    ngx.log(ngx.INFO, "==== session_id not set")
+  ngx.log(ngx.INFO, "==== session_id not set")
 end
 
+-- unset all border* cookies (expires now() - 1yr)
+cookie.expire_all()
 ngx.redirect(destination)

--- a/src/redirect.lua
+++ b/src/redirect.lua
@@ -1,4 +1,5 @@
 local sessionid = require("sessionid")
+local cookie = require("cookie")
 
 local original_url = ngx.var.original_uri
 
@@ -14,7 +15,7 @@ ngx.log(ngx.DEBUG, "==== POST /session?id=BP_URL_SID_" .. session_id  ..
 
 if res.status == ngx.HTTP_CREATED then
   -- set the cookie with the session_id
-  ngx.header['Set-Cookie'] = 'border_session=' .. session_id .. '; path=/; HttpOnly; Secure;'
+  cookie.set_session(session_id)
   -- Redirect to account service login
   ngx.redirect(account_resource)
 else

--- a/src/sessionid.lua
+++ b/src/sessionid.lua
@@ -229,11 +229,13 @@ local function is_valid(session_id)
 
   -- check for the obvious
   if not data or not signature or not ts then
+    ngx.log(ngx.DEBUG, "=== missing data or sig or ts")
     return false
   end
 
   -- check whether the cookie expired already
   if ngx.time() > ts + SESSION_COOKIE_LIFETIME then
+    ngx.log(ngx.DEBUG, "=== expired")
     return false
   end
 
@@ -243,6 +245,7 @@ local function is_valid(session_id)
 
   -- check whether data or signature became nil (happens in case it couldn't be decoded properly)
   if not data or #data ~= DATA_LENGTH or not signature or #signature ~= HMAC_SHA1_SIGN_LENGTH then
+    ngx.log(ngx.DEBUG, "=== data or sig became nil")
     return false
   end
 

--- a/src/validate.lua
+++ b/src/validate.lua
@@ -87,5 +87,6 @@ end
 
 -- If we made it this far, we're good. Inject the Auth-Token header
 ngx.header['Auth-Token'] = auth_token
+
 ngx.log(ngx.INFO, "==== request auth header set")
 ngx.exit(ngx.HTTP_OK)

--- a/t/csrf.t
+++ b/t/csrf.t
@@ -1,0 +1,288 @@
+use lib 'lib';
+use Test::Nginx::Socket;
+
+$ENV{TEST_NGINX_MEMCACHED_PORT} ||= 11211;
+
+plan tests => $Test::Nginx::Socket::RepeatEach * 2 * blocks();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: valid CSRF header and cookie
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+
+upstream b {
+  server 127.0.0.1:$TEST_NGINX_SERVER_PORT; # self
+}
+
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /testpath {
+    echo_status 200;
+    echo_duplicate 1 $echo_client_request_headers;
+    echo 'everything is ok';
+    echo_flush;
+}
+location /b/testpath {
+    echo_location /setup;
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
+    # http://hostname/upstream_name/uri -> http://upstream_name/uri
+    rewrite ^/([^/]+)/?(.*)$ /$2 break;
+    proxy_pass         http://$1;
+    proxy_redirect     off;
+    proxy_set_header   Host $host;
+}
+--- request
+GET /b/testpath
+--- more_headers
+X-Border-Csrf: MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+Cookie: border_csrf=MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code: 200
+--- response_body_like
+.+X-Border-Csrf-Verified: true.+everything is ok$
+
+=== TEST 2: valid CSRF header and invalid cookie
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+
+upstream b {
+  server 127.0.0.1:$TEST_NGINX_SERVER_PORT; # self
+}
+
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /testpath {
+    echo_status 200;
+    echo_duplicate 1 $echo_client_request_headers;
+    echo 'everything is ok';
+    echo_flush;
+}
+location /b/testpath {
+    echo_location /setup;
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
+    # http://hostname/upstream_name/uri -> http://upstream_name/uri
+    rewrite ^/([^/]+)/?(.*)$ /$2 break;
+    proxy_pass         http://$1;
+    proxy_redirect     off;
+    proxy_set_header   Host $host;
+}
+--- request
+GET /b/testpath
+--- more_headers
+X-Border-Csrf: MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+Cookie: border_csrf=invalidinvalidinvalid-**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code: 200
+--- response_body_like
+.+X-Border-Csrf-Verified: false.+everything is ok$
+
+=== TEST 3: valid CSRF cookie and invalid header
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+
+upstream b {
+  server 127.0.0.1:$TEST_NGINX_SERVER_PORT; # self
+}
+
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /testpath {
+    echo_status 200;
+    echo_duplicate 1 $echo_client_request_headers;
+    echo 'everything is ok';
+    echo_flush;
+}
+location /b/testpath {
+    echo_location /setup;
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
+    # http://hostname/upstream_name/uri -> http://upstream_name/uri
+    rewrite ^/([^/]+)/?(.*)$ /$2 break;
+    proxy_pass         http://$1;
+    proxy_redirect     off;
+    proxy_set_header   Host $host;
+}
+--- request
+GET /b/testpath
+--- more_headers
+X-Border-Csrf: invalidinvalidinvalid-**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+Cookie: border_csrf=MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code: 200
+--- response_body_like
+.+X-Border-Csrf-Verified: false.+everything is ok$
+
+=== TEST 4: valid CSRF cookie and missing header
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+
+upstream b {
+  server 127.0.0.1:$TEST_NGINX_SERVER_PORT; # self
+}
+
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /testpath {
+    echo_status 200;
+    echo_duplicate 1 $echo_client_request_headers;
+    echo 'everything is ok';
+    echo_flush;
+}
+location /b/testpath {
+    echo_location /setup;
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
+    # http://hostname/upstream_name/uri -> http://upstream_name/uri
+    rewrite ^/([^/]+)/?(.*)$ /$2 break;
+    proxy_pass         http://$1;
+    proxy_redirect     off;
+    proxy_set_header   Host $host;
+}
+--- request
+GET /b/testpath
+--- more_headers
+Cookie: border_csrf=MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code: 200
+--- response_body_like
+.+X-Border-Csrf-Verified: false.+everything is ok$
+
+=== TEST 5: valid CSRF header and missing cookie
+--- main_config
+--- http_config
+lua_package_path "./build/usr/share/borderpatrol/?.lua;./build/usr/share/lua/5.1/?.lua;;";
+lua_package_cpath "./build/usr/lib/lua/5.1/?.so;;";
+
+upstream b {
+  server 127.0.0.1:$TEST_NGINX_SERVER_PORT; # self
+}
+
+--- config
+location /memc_setup {
+    internal;
+    set $memc_cmd $arg_cmd;
+    set $memc_key $arg_key;
+
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location = /setup {
+    # clear
+    echo_subrequest GET '/memc_setup?cmd=flush_all';
+    echo_subrequest POST '/memc_setup?key=BP_LEASE' -b '1';
+    echo_subrequest POST '/memc_setup?key=BPS1' -b 'mysecret:1595116800';
+}
+location = /session {
+    internal;
+    set $memc_key $arg_id;
+    memc_pass 127.0.0.1:$TEST_NGINX_MEMCACHED_PORT;
+}
+location /testpath {
+    echo_status 200;
+    echo_duplicate 1 $echo_client_request_headers;
+    echo 'everything is ok';
+    echo_flush;
+}
+location /b/testpath {
+    echo_location /setup;
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    proxy_set_header X-Border-Csrf-Verified $csrf_verified;
+
+    # http://hostname/upstream_name/uri -> http://upstream_name/uri
+    rewrite ^/([^/]+)/?(.*)$ /$2 break;
+    proxy_pass         http://$1;
+    proxy_redirect     off;
+    proxy_set_header   Host $host;
+}
+--- request
+GET /b/testpath
+--- more_headers
+X-Border-Csrf: MDEyMzQ1Njc4OTAxMjM0NQ**:1595116800:9Wc0CzZKO7Mq5Y2NbTaHrIp/gMg*
+--- error_code: 200
+--- response_body_like
+.+X-Border-Csrf-Verified: false.+everything is ok$

--- a/t/services/api_service2.rb
+++ b/t/services/api_service2.rb
@@ -2,6 +2,7 @@ require 'sinatra'
 
 ["/", "/first/second"].each do |path|
   get path do
+    $stderr.write "apiserver2 csrf: #{request.env['HTTP_X_BORDER_CSRF_VERIFIED']}"
     token = request.env['HTTP_AUTH_TOKEN']
     $stderr.write "apiserver2 #{request.url} token = #{token}\n"
 


### PR DESCRIPTION
Fixes #60

This commits has 3 main components:
 - CSRF verification/validation module
 - Cookie module which handles the multiple cookies
 - Use of these two modules in the right places

CSRF cookie is set upon successful login and validated on every request
since we have no guarantee that every mutation is a
POST/PUT/PATCH/DELETE. It doesn't cost much to inject the header, so
let's do it on every request.

CSRF and Session cookies are removed upon a call to logout.lua