### PR TITLE
Fix duplicate access_by error

### DIFF
--- a/src/config/location_defaults.conf
+++ b/src/config/location_defaults.conf
@@ -12,7 +12,7 @@ proxy_set_header Auth-token $auth_token;
 
 # Inject the CSRF protection header for every authenticated request
 set $csrf_verified 'false';
-access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+set_by_lua_file $csrf_verified '../../build/usr/share/borderpatrol/csrf.lua';
 proxy_set_header X-Border-Csrf-Verified $csrf_verified;
 
 # tell upstreams the $schema


### PR DESCRIPTION
lua-resty doesn't allow for multiple access_by_lua* calls in the same
location, so I've updated this to use set_by_lua_file.