### PR TITLE
Ensure csrf cookie is readable by javascript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Debian package name & version
 MAJOR_VER=0
 MINOR_VER=4
-PATCH_VER=0
+PATCH_VER=1
 PKG_NAME=borderpatrol
 BUILD_VER=0${BUILD_NUMBER}-dev
 

--- a/src/cookie.lua
+++ b/src/cookie.lua
@@ -7,9 +7,18 @@ local csrf_cookie_name = 'border_csrf'
 
 --
 -- Creates the cookie from the name and value parameters
+-- name The cookie name
+-- value The value of the cookie
+-- notHttp Will append 'HttpOnly' if set to anything but true
 --
-local function make_cookie(name, value)
-  return (name .. '=' .. value .. '; path=/; HttpOnly; Secure;')
+local function make_cookie(name, value, notHttp)
+  cookie = name .. '=' .. value .. '; path=/; Secure;'
+
+  if (notHttp == true) then
+    return cookie
+  else
+    return (cookie .. ' HttpOnly;')
+  end
 end
 
 --
@@ -21,17 +30,19 @@ end
 
 --
 -- Returns the cookie for sessions
+-- This must be HttpOnly so that javascript cannot read the value
 -- session_id The id for the session cookie
 --
 local function gen_session(session_id)
-  return make_cookie(session_cookie_name, session_id)
+  return make_cookie(session_cookie_name, session_id, false)
 end
 
 --
 -- Creates the cookie for csrf protection, generating a unique id for it
+-- This must be non-HttpOnly so that javascript can read the value
 --
 local function gen_csrf()
-  return make_cookie(csrf_cookie_name, sessionid.generate())
+  return make_cookie(csrf_cookie_name, sessionid.generate(), true)
 end
 
 --


### PR DESCRIPTION
javascript cannot read a cookie loaded by 'HttpOnly', since we are only
allowing the cookie to be set after successful https login, we should be
fine to allow the csrf cookie be created without the 'httponly' setting.