### PR TITLE
Fix yield across metamethod/C-call boundary

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -1,16 +1,24 @@
-if (ngx.var.auth_token == "") then
-  -- make a sub request to pull session data
-  local res = ngx.location.capture("/auth")
+local module = {}
 
-  ngx.log(ngx.DEBUG, "==== GET /auth " .. res.status .. " " .. res.body)
+local function set_auth_token()
+  if (ngx.var.auth_token == "") then
+    -- make a sub request to pull session data
+    local res = ngx.location.capture("/auth")
 
-  if res.status == ngx.HTTP_OK then
-    -- set the auth token in the request variables so it can be pulled out
-    -- and passed as a header then return and allow the request chain to
-    -- continue. if there's no auth token do the same thing, allowing the
-    -- upstream service to allow or deny access.
-    ngx.var.auth_token = res.header['Auth-Token']
+    ngx.log(ngx.DEBUG, "==== GET /auth " .. res.status .. " " .. res.body)
+
+    if res.status == ngx.HTTP_OK then
+      -- set the auth token in the request variables so it can be pulled out
+      -- and passed as a header then return and allow the request chain to
+      -- continue. if there's no auth token do the same thing, allowing the
+      -- upstream service to allow or deny access.
+      ngx.var.auth_token = res.header['Auth-Token']
+    end
+  else
+    ngx.log(ngx.DEBUG, "==== skipping GET /auth since auth_token is present: [" .. ngx.var.auth_token .. "]")
   end
-else
-  ngx.log(ngx.DEBUG, "==== skipping GET /auth since auth_token is present: [" .. ngx.var.auth_token .. "]")
 end
+
+module.set_auth_token = set_auth_token
+
+return module

--- a/src/border_vars.lua
+++ b/src/border_vars.lua
@@ -1,0 +1,8 @@
+local auth = require("access")
+local csrf = require("csrf")
+
+-- ensure we are setting these everytime
+-- $auth_token
+auth.set_auth_token()
+-- $csrf_verified
+csrf.set_csrf_verified()

--- a/src/config/location_defaults.conf
+++ b/src/config/location_defaults.conf
@@ -6,13 +6,13 @@ if ($http_via) {
 set $original_uri $uri;
 
 # ensure Auth-Token header gets populated for this service
-set $auth_token $http_auth_token;
-access_by_lua_file '../../build/usr/share/borderpatrol/access.lua';
-proxy_set_header Auth-token $auth_token;
-
 # Inject the CSRF protection header for every authenticated request
+set $auth_token $http_auth_token;
 set $csrf_verified 'false';
-set_by_lua_file $csrf_verified '../../build/usr/share/borderpatrol/csrf.lua';
+
+access_by_lua_file '../../build/usr/share/borderpatrol/border_vars.lua';
+
+proxy_set_header Auth-token $auth_token;
 proxy_set_header X-Border-Csrf-Verified $csrf_verified;
 
 # tell upstreams the $schema

--- a/src/config/nginx.conf.sample
+++ b/src/config/nginx.conf.sample
@@ -45,7 +45,7 @@ http {
   # this is the account service. displays the login screen and also calls the auth service
   # to get a master token and a service token
   upstream account {
-    server localhost:9084; # use this if you are running the mock account service
+    server localhost:4567; # use this if you are running the mock account service
   }
 
   # Nginx Lua has no SSL support for cosockets. This is unfortunate.

--- a/src/csrf.lua
+++ b/src/csrf.lua
@@ -81,4 +81,6 @@ local function set_csrf_verified()
 
 end
 
-set_csrf_verified()
+module.set_csrf_verified = set_csrf_verified
+
+return module

--- a/t/access.t
+++ b/t/access.t
@@ -74,7 +74,8 @@ location /auth {
 }
 location /b/testpath {
     set $auth_token $http_auth_token;
-    access_by_lua_file '../../build/usr/share/borderpatrol/access.lua';
+    set $csrf_verified 'false';
+    access_by_lua_file '../../build/usr/share/borderpatrol/border_vars.lua';
     proxy_set_header Auth-Token $auth_token;
 
     # http://hostname/upstream_name/uri -> http://upstream_name/uri
@@ -124,7 +125,7 @@ location @redirect {
     # For Ajax requests, we want to return a 401 with a descriptive message
     if ($http_x_requested_with = "XMLHttpRequest") {
         more_set_headers 'Content-Type: application/json';
-        return 401 '{"CODE": "SESSION_EXPIRED"}';
+        return 401 '{"CODE": "SESSION_EXPIRED"}\n';
     }
     content_by_lua_file '../../build/usr/share/borderpatrol/redirect.lua';
 }
@@ -134,7 +135,8 @@ location /auth {
 }
 location /b/testpath {
     set $auth_token $http_auth_token;
-    content_by_lua_file '../../build/usr/share/borderpatrol/access.lua';
+    set $csrf_verified 'false';
+    content_by_lua_file '../../build/usr/share/borderpatrol/border_vars.lua';
     proxy_set_header Auth-Token $auth_token;
 
     # http://hostname/upstream_name/uri -> http://upstream_name/uri
@@ -153,3 +155,4 @@ X-Requested-With: XMLHttpRequest
 Content-Type: application/json
 --- response_body
 {"CODE": "SESSION_EXPIRED"}
+

--- a/t/csrf.t
+++ b/t/csrf.t
@@ -46,8 +46,9 @@ location /testpath {
 }
 location /b/testpath {
     echo_location /setup;
+    set $auth_token '';
     set $csrf_verified 'false';
-    access_by_lua_file '../../build/usr/share/borderpatrol/csrf.lua';
+    access_by_lua_file '../../build/usr/share/borderpatrol/border_vars.lua';
     proxy_set_header X-Border-Csrf-Verified $csrf_verified;
 
     # http://hostname/upstream_name/uri -> http://upstream_name/uri


### PR DESCRIPTION
Since lua-memcached requires that we use the access_by* lua directive,
and since we cannot use multiple access_by* directives in the same
location, we have to merge the two into a single call.

Unfortunately, the straightforward implementation using `dofile` also
isn't supported in the lua/jit version(s) we are using.

The fix is to lift these calls into actual modules and then call the
modules from a single access_by*.

This change also updates tests to take this into account