### PR TITLE
Capture the url and arguments (not just the url) before redirecting

### DIFF
--- a/src/config/location_defaults.conf
+++ b/src/config/location_defaults.conf
@@ -3,7 +3,7 @@ set $via "1.1 $host (Borderpatrol)";
 if ($http_via) {
   set $via "$http_via, 1.1 $host (Borderpatrol)";
 }
-set $original_uri $uri;
+set $original_uri $request_uri;
 
 # ensure Auth-Token header gets populated for this service
 # Inject the CSRF protection header for every authenticated request


### PR DESCRIPTION
Before we redirect to the Login screen, we are currently capturing the
original url the user was going to, so we can redirect them there once
they log in. However, since we are capturing $uri rather than
$request_uri, we are losing the url arguments.

From the Nginx docs

$request_uri : full original request URI (with arguments)
$uri : current URI in request, normalized